### PR TITLE
Add ability to request additional scopes from Idp

### DIFF
--- a/MantisOIDC.php
+++ b/MantisOIDC.php
@@ -37,7 +37,10 @@ class MantisOIDCPlugin extends MantisPlugin {
 	function config() {
 		return array(
 			'clientId'     => '',
-			'clientSecret' => ''
+			'clientSecret' => '',
+			'oidc_scopes' => array('openid'),
+			'oidc_uid_claim' => 'name',
+			'oidc_find_user_by' => 'name',
 		);
 	}
 

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -5,4 +5,5 @@ $s_plugin_MantisOIDC_save = 'SAVE';
 $s_plugin_MantisOIDC_login_button_default = 'Sign in';
 $s_plugin_MantisOIDC_seperator_text = 'OR';
 $s_plugin_MantisOIDC_user_not_available = 'Sorry, there is no account associated with the provided login data. Please contact an <a href="mailto:%1$s" title="Contact Admin.">Administrator</a>';
+$s_plugin_MantisOIDC_user_id_not_transmitted = 'Sorry, the identity provider did not transmit the correct login data. Please contact an <a href="mailto:%1$s" title="Contact Admin.">Administrator</a>';
 

--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -5,3 +5,4 @@ $s_plugin_MantisOIDC_save = 'Speichern';
 $s_plugin_MantisOIDC_login_button_default = 'Anmelden';
 $s_plugin_MantisOIDC_seperator_text = 'ODER';
 $s_plugin_MantisOIDC_user_not_available = 'Es gibt kein Konto, das mit diesen Benutzerdaten verbunden ist. Bitte wenden Sie sich an einen <a href="mailto:%1$s" title="Den Webmaster per E-Mail kontaktieren.">Administrator</a>.';
+$s_plugin_MantisOIDC_user_id_not_transmitted = 'Der Identity Provider hat Daten, die zum Login erforderlich sind nicht übermittelt. Bitte wenden Sie sich an einen <a href="mailto:%1$s" title="Den Webmaster per E-Mail kontaktieren.">Administrator</a>.';

--- a/pages/config.php
+++ b/pages/config.php
@@ -10,6 +10,13 @@ layout_page_header( plugin_lang_get( 'title' ) );
 layout_page_begin( 'manage_overview_page.php' );
 
 print_manage_menu( 'manage_plugin_page.php' );
+
+$oidc_scopes = plugin_config_get( 'oidc_scopes' );
+if (empty($oidc_scopes)) {
+	$oidc_scopes = ["openid"];
+}
+$oidc_find_user_by = plugin_config_get( 'oidc_find_user_by' );
+
 ?>
     <div class="col-md-12 col-xs-12">
         <div class="space-10"></div>
@@ -52,6 +59,32 @@ print_manage_menu( 'manage_plugin_page.php' );
                                    value="<?php echo plugin_config_get( 'openIDClientSecret', '' ); ?>">
                         </div>
                     </div>
+
+					<div class="form-group">
+						<label for="oidc_scopes" class="col-sm-3 control-label label-info label-white">Scopes<br /><span class="smaller-75">Scopes to request from the IdP (Space separated)</span></label>
+						<div class="col-sm-7">
+							<input type="text" class="form-control" id="oidc_scopes" name="oidc_scopes" placeholder="openid"
+								   value="<?php echo join(" ", $oidc_scopes); ?>">
+						</div>
+					</div>
+
+					<div class="form-group">
+						<label for="oidc_uid_claim" class="col-sm-3 control-label label-info label-white">User ID Claim<br /><span class="smaller-75">Claim that contains the value that the user will be identified by. (e.g. 'sub', 'name', 'email')</span></label>
+						<div class="col-sm-7">
+							<input type="text" class="form-control" id="oidc_uid_claim" name="oidc_uid_claim" placeholder="name"
+									value="<?php echo plugin_config_get( 'oidc_uid_claim' ); ?>">
+						</div>
+					</div>
+
+					<div class="form-group">
+						<label for="oidc_find_user_by" class="col-sm-3 control-label label-info label-white">Find User By<br /><span class="smaller-75">Select whether to match users by name or by email. This depends on what value is transmitted by the IdP in the selected user ID claim.</span></label>
+						<div class="col-sm-7">
+							<select class="form-control" id="oidc_find_user_by" name="oidc_find_user_by">
+								<option value="email" <?php echo ($oidc_find_user_by == 'email') ? 'selected' : ''; ?>>Email</option>
+								<option value="name" <?php echo ($oidc_find_user_by == 'name') ? 'selected' : ''; ?>>Name</option>
+							</select>
+						</div>
+					</div>
 
 					<div class="form-group">
 						<label for="oidc_role" class="col-sm-3 control-label label-info label-white">User Role<br /><span class="smaller-75">Role in you OIDC system a user has to have, to successfully login into MantisBT. Leave empty if every user is allowed to login (as long as they have an MantisBT account).</span></label>

--- a/pages/config_update.php
+++ b/pages/config_update.php
@@ -7,6 +7,9 @@
     plugin_config_set('openIDAuthURL', strip_tags(gpc_get_string('oidaurl')));
     plugin_config_set('openIDClientID', strip_tags(gpc_get_string('oidclientid')));
     plugin_config_set('openIDClientSecret', strip_tags(gpc_get_string('oidsecret')));
+    plugin_config_set('oidc_scopes', explode(" ", strip_tags(gpc_get_string('oidc_scopes'))));
+    plugin_config_set('oidc_uid_claim', strip_tags(gpc_get_string('oidc_uid_claim')));
+    plugin_config_set('oidc_find_user_by', strip_tags(gpc_get_string('oidc_find_user_by')));
     plugin_config_set('oidc_role', strip_tags(gpc_get_string('oidc_role')));
 
     plugin_config_set('login_button_text', strip_tags(gpc_get_string('login_button_text')));

--- a/pages/oidcStart.php
+++ b/pages/oidcStart.php
@@ -13,4 +13,6 @@
 
     $oidc->setRedirectUrl(substr(config_get('path'), 0, -1).plugin_page( 'redirect'));
 
+    $oidc->addScope(plugin_config_get('oidc_scopes'));
+
     $oidc->authenticate();

--- a/pages/redirect.php
+++ b/pages/redirect.php
@@ -25,7 +25,31 @@
 
     $data = $oidc->introspectToken($access_token);
 
-    $user_id = user_get_id_by_name($data->username);
+    $uid_claim = plugin_config_get('oidc_uid_claim');
+    if ( !isset($data->{$uid_claim}) ) {
+        layout_login_page_begin();
+        echo '<div class="col-md-offset-3 col-md-6 col-sm-10 col-sm-offset-1">
+                <div class="login-container">
+                  <div class="space-12 hidden-480"></div>'.
+                  layout_login_page_logo().
+                 '<div class="space-24 hidden-480"></div>
+                 <div class="alert alert-danger"><p>' . sprintf(plugin_lang_get( 'user_id_not_transmitted' ), string_html_specialchars( config_get_global( 'webmaster_email' ) ) ) . '</p></div>
+               </div>
+              </div>';
+
+        layout_login_page_end();
+
+        return false;
+    }
+
+    $oidc_uid = $data->{$uid_claim};
+
+    $find_user_by = plugin_config_get('oidc_find_user_by');
+    if ( $find_user_by == "email" ) {
+        $user_id = user_get_id_by_email($data->email);
+    } else {
+        $user_id = user_get_id_by_name($data->username);
+    }
 
     $login_success = true;
 


### PR DESCRIPTION
First of all thank you for you work on this plugin. An OIDC for Mantis was definitely needed.

I tried to get this working with authentik but that does not transmit any username when only the `openid` scope is requested.
So I added an configuration option for requesting additional scopes (like `profile` or `email`).

Also I would like to match users by email rather than username, so I made that configurable as well.

I set the default values so that the current behavior should be left unchanged.
